### PR TITLE
Fix for  self chosen users table name

### DIFF
--- a/lib/Dancer2/Plugin/Auth/YARBAC/Provider/Database.pm
+++ b/lib/Dancer2/Plugin/Auth/YARBAC/Provider/Database.pm
@@ -1007,7 +1007,7 @@ sub _sanitize_user_params
         delete $params->{password};
     }
 
-    my $sql = 'SELECT * FROM users LIMIT 0';
+    my $sql = 'SELECT * FROM ' . $self->users_table . ' LIMIT 0';
     my $sth = $self->db->prepare( $sql );
 
     $sth->execute();


### PR DESCRIPTION
Please update this module so altering the config setting for the users table name doesn't result in a crash.

error:
DBD::mysql::st execute failed: Table 'ryact-demo.users' doesn't exist at /Users/rory/Dev/Ryact/local/lib/perl5/Dancer2/Plugin/Auth/YARBAC/Provider/Database.pm line 1013.